### PR TITLE
Update generator to be Rails 4 compliant

### DIFF
--- a/lib/generators/pg_audit_log/install_generator.rb
+++ b/lib/generators/pg_audit_log/install_generator.rb
@@ -2,17 +2,17 @@ require "rails/generators/active_record"
 
 module PgAuditLog
   module Generators
-    class InstallGenerator < Rails::Generators::Base
-      include Rails::Generators::Migration
-      extend ::ActiveRecord::Generators::Migration
-
+    class InstallGenerator < ::ActiveRecord::Generators::Base
+      # ActiveRecord::Generators::Base inherits from Rails::Generators::NamedBase which requires a NAME parameter for the
+      # new table name. Our generator doesn't require a name, so we just set a random name here.
+      argument :name, type: :string, default: "random_name"
+      
       source_root File.expand_path('../templates', __FILE__)
 
       def install
         directory "lib/tasks"
         migration_template "migration.rb", "db/migrate/install_pg_audit_log"
       end
-
     end
   end
 end


### PR DESCRIPTION
The default argument workaround was originally found here: https://github.com/norman/friendly_id/pull/392
