### PR TITLE
Remove correct migration and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ All SQL `INSERT`s, `UPDATE`s, and `DELETE`s will be captured. Record columns tha
 
         rails generate pg_audit_log:install
 
-- Install the PostgreSQL function and triggers for your project:
-
-        rake pg_audit_log:install
-
 ## Usage
 
 The PgAuditLog::Entry ActiveRecord model represents a single entry in the audit log table. Each entry represents a single change to a single field of a record in a table. So if you change 3 columns of a record, that will generate 3 corresponding PgAuditLog::Entry records.
@@ -33,6 +29,7 @@ You can see the SQL it injects on every query by running with LOG_AUDIT_SQL
 
 ### Migrations
 
+Running `rake db:migrate` will install the audit log table, as well as the triggers and functions needed for `pg_audit_log` to work properly.
 TODO
 
 ### schema.rb and development_structure.sql

--- a/lib/generators/pg_audit_log/install_generator.rb
+++ b/lib/generators/pg_audit_log/install_generator.rb
@@ -9,8 +9,7 @@ module PgAuditLog
       source_root File.expand_path('../templates', __FILE__)
 
       def install
-        directory "lib/tasks"
-        migration_template "migration.rb", "db/migrate/install_pg_audit_log"
+        migration_template "migration.rb", "db/migrate/install_pg_audit_log.rb"
       end
 
     end

--- a/lib/generators/pg_audit_log/templates/migration.rb
+++ b/lib/generators/pg_audit_log/templates/migration.rb
@@ -1,15 +1,13 @@
 class InstallPgAuditLog < ActiveRecord::Migration
-
-  def self.up
-    PgAuditLog::Entry.install
+  def up
+    PgAuditLog::Entry.install unless PgAuditLog::Entry.installed?
     PgAuditLog::Function.install
     PgAuditLog::Triggers.install
   end
 
-  def self.down
+  def down
     PgAuditLog::Triggers.uninstall
     PgAuditLog::Function.uninstall
     PgAuditLog::Entry.uninstall
   end
 end
-


### PR DESCRIPTION
- The install task does the same thing as the migration.  No need to run it initially.
- Migrations require a `.rb` extension to get picked up by Rails