### PR TITLE
skip created_at and updated_at fields

### DIFF
--- a/lib/pg_audit_log/function.rb
+++ b/lib/pg_audit_log/function.rb
@@ -81,6 +81,8 @@ module PgAuditLog
                 column_name := col.column_name;
                 IF TG_RELNAME = '#{users_table_name}' AND column_name = '#{users_access_column}' THEN
                   NULL;
+                ELSIF column_name = 'created_at' OR column_name = 'updated_at' THEN
+                  NULL;
                 ELSE
                   IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
                     EXECUTE 'SELECT CAST($1 . '|| column_name ||' AS TEXT)' INTO new_value USING NEW;


### PR DESCRIPTION
Hi!

Would you be willing to incorporate this small change to pg_audit_log, which skips the default columns created by rails for timestamping changes within a table?

thanks in advance
Brian
