### PR TITLE
Don't load columns from tables in other schemas

### DIFF
--- a/lib/pg_audit_log/function.rb
+++ b/lib/pg_audit_log/function.rb
@@ -75,7 +75,7 @@ module PgAuditLog
               INTO primary_key_column USING TG_RELNAME;
               primary_key_value := NULL;
 
-              FOR col IN SELECT * FROM information_schema.columns WHERE table_name = TG_RELNAME LOOP
+              FOR col IN SELECT * FROM information_schema.columns WHERE table_name = TG_RELNAME AND table_schema = 'public' LOOP
                 new_value := NULL;
                 old_value := NULL;
                 column_name := col.column_name;


### PR DESCRIPTION
By default Rails puts its tables in the `public` schema. But sometimes other schemas are used, for instance for [history](https://www.youtube.com/watch?v=TRgni5q0YM8), reporting, [multiple tenants](https://github.com/influitive/apartment), etc. It is common for these other schemas to have tables with the same name as the table from the `public` schema (see links above). Currently when pg_audit_log queries `information_schema.columns`, it gets all columns from *all schemas*, which causes errors when it tries to record the changes that happened. This change makes pg_audit_log look only in the `public` schema, so it doesn't break if other schemas are used.