### PR TITLE
Disable PL/pgSQL creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ All SQL `INSERT`s, `UPDATE`s, and `DELETE`s will be captured. Record columns tha
 
 ## Installation
 
-- First, enable plpgsql langauges in your postgresql instance. Execute the following as a superuser in postgres make sure your database has plpgsql enabled:
-
-        CREATE OR REPLACE PROCEDURAL LANGUAGE plpgsql;
-
 - Generate the appropriate Rails files:
 
         rails generate pg_audit_log:install

--- a/lib/pg_audit_log/function.rb
+++ b/lib/pg_audit_log/function.rb
@@ -45,7 +45,6 @@ module PgAuditLog
 
       def install
         execute <<-SQL
-        CREATE OR REPLACE PROCEDURAL LANGUAGE plpgsql;
         CREATE OR REPLACE FUNCTION #{name}() RETURNS trigger
         LANGUAGE plpgsql
         AS $_$


### PR DESCRIPTION
Disable PL/pgSQL procedural language creation, since it's created by default in modern postgres, and attempting to create it breaks hosted postrgres.